### PR TITLE
fix unit tests, NPE and validation with empty regexp value

### DIFF
--- a/form-editor-cae/src/main/java/com/tallence/formeditor/cae/handler/FormController.java
+++ b/form-editor-cae/src/main/java/com/tallence/formeditor/cae/handler/FormController.java
@@ -153,7 +153,7 @@ public class FormController {
                   target.getContentId());
         }
         MultipartHttpServletRequest multipartHttpServletRequest = (MultipartHttpServletRequest) request;
-        MultipartFile file = multipartHttpServletRequest.getFile(formElement.getId());
+        MultipartFile file = multipartHttpServletRequest.getFile(formElement.getTechnicalName());
         ((FileUpload) formElement).setValue(file);
         files.add(file);
       } else {

--- a/form-editor-cae/src/main/java/com/tallence/formeditor/cae/validator/TextValidator.java
+++ b/form-editor-cae/src/main/java/com/tallence/formeditor/cae/validator/TextValidator.java
@@ -87,7 +87,7 @@ public class TextValidator implements Validator<String> {
   }
 
   public void setRegexp(String regexp) {
-    if (regexp != null) {
+    if (StringUtils.hasText(regexp)) {
       this.regexp = Pattern.compile(regexp);
     } else {
       this.regexp = null;

--- a/form-editor-cae/src/test/java/com/tallence/formeditor/cae/handler/FormControllerTest.java
+++ b/form-editor-cae/src/test/java/com/tallence/formeditor/cae/handler/FormControllerTest.java
@@ -91,14 +91,14 @@ public class FormControllerTest {
   public void testValidPost() throws Exception {
 
     mvc.perform(fileUpload(TEST_URL)
-        .param("TextField", "12345")
-        .param("NumberField", "18")
-        .param("RadioButtonsMandatory", "12345")
-        .param("CheckBoxesMandatory", "12345")
-        .param("SelectBoxMandatory", "12345")
-        .param("TextArea", "ist Text")
-        .param("UsersMail", MAIL_ADDRESS_TEST)
-        .param("ConsentFormCheckBox", "on")
+        .param("TextField_TextField", "12345")
+        .param("NumberField_NumberField", "18")
+        .param("RadioButtonGroup_RadioButtonsMandatory", "12345")
+        .param("CheckBoxesGroup_CheckBoxesMandatory", "12345")
+        .param("SelectBox_SelectBoxMandatory", "12345")
+        .param("TextArea_TextArea", "ist Text")
+        .param("UsersMail_UsersMail", MAIL_ADDRESS_TEST)
+        .param("ConsentFormCheckBox_ConsentFormCheckBox", "on")
     )
         .andExpect(status().is2xxSuccessful())
         .andExpect(content().string("{\"success\":true,\"error\":null}"))
@@ -113,25 +113,25 @@ public class FormControllerTest {
   @Test
   public void testValidPostWithFile() throws Exception {
 
-    MockMultipartFile firstFile = new MockMultipartFile("FileUpload", "filename.txt", "text/plain", "some xml".getBytes());
+    MockMultipartFile firstFile = new MockMultipartFile("FileUpload_FileUpload", "filename.txt", "text/plain", "some xml".getBytes());
 
     mvc.perform(fileUpload(TEST_URL)
         .file(firstFile)
-        .param("TextField", "12345")
-        .param("NumberField", "18")
-        .param("RadioButtonsMandatory", "12345")
-        .param("CheckBoxesMandatory", "12345")
-        .param("SelectBoxMandatory", "12345")
-        .param("TextArea", "ist Text")
-        .param("UsersMail", MAIL_ADDRESS_TEST)
-        .param("ConsentFormCheckBox", "on")
+        .param("TextField_TextField", "12345")
+        .param("NumberField_NumberField", "18")
+        .param("RadioButtonGroup_RadioButtonsMandatory", "12345")
+        .param("CheckBoxesGroup_CheckBoxesMandatory", "12345")
+        .param("SelectBox_SelectBoxMandatory", "12345")
+        .param("TextArea_TextArea", "ist Text")
+        .param("UsersMail_UsersMail", MAIL_ADDRESS_TEST)
+        .param("ConsentFormCheckBox_ConsentFormCheckBox", "on")
     )
         .andExpect(status().is2xxSuccessful())
         .andExpect(content().string("{\"success\":true,\"error\":null}"))
         .andDo(MockMvcResultHandlers.print());
 
-    assertEquals(FORM_DATA_SERIALIZED + "FileUpload: filename.txt<br/>", storageAdapterMock.formData);
-    assertEquals(FORM_DATA_SERIALIZED + "FileUpload: filename.txt<br/>", mailAdapterMock.usersFormData);
+    assertEquals(FORM_DATA_SERIALIZED + "FileUpload_FileUpload: filename.txt<br/>", storageAdapterMock.formData);
+    assertEquals(FORM_DATA_SERIALIZED + "FileUpload_FileUpload: filename.txt<br/>", mailAdapterMock.usersFormData);
     assertEquals(MAIL_ADDRESS_TEST, mailAdapterMock.usersRecipient);
   }
 
@@ -141,8 +141,8 @@ public class FormControllerTest {
     URI mailTestUrl = UriComponentsBuilder.fromUriString(PROCESS_SOCIAL_FORM).buildAndExpand("6", "4").toUri();
 
     mvc.perform(post(mailTestUrl)
-        .param("TextArea", "ist Text")
-        .param("UsersMail", MAIL_ADDRESS_TEST)
+        .param("TextArea_TextArea", "ist Text")
+        .param("UsersMail_UsersMail", MAIL_ADDRESS_TEST)
     )
         .andExpect(status().is2xxSuccessful())
         .andExpect(content().string("{\"success\":true,\"error\":null}"))
@@ -161,7 +161,7 @@ public class FormControllerTest {
   public void testInValidPost() throws Exception {
 
     //Performing a post with only the TextField given will cause a validation error, because other mandatory fields are missing.
-    mvc.perform(fileUpload(TEST_URL).param("TextField", "12345"))
+    mvc.perform(fileUpload(TEST_URL).param("TextField_TextField", "12345"))
         .andExpect(status().is4xxClientError())
         .andExpect(content().string("{\"success\":false,\"error\":\"server-validation-failed\"}"))
         .andDo(MockMvcResultHandlers.print());

--- a/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/FormActionValidator.java
+++ b/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/FormActionValidator.java
@@ -10,7 +10,6 @@ import com.coremedia.rest.cap.validation.ContentTypeValidatorBase;
 import com.coremedia.rest.validation.Issues;
 import com.coremedia.rest.validation.Severity;
 import com.tallence.formeditor.contentbeans.FormEditor;
-import org.springframework.util.StringUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +34,7 @@ public class FormActionValidator extends ContentTypeValidatorBase {
       return;
     }
 
-    if (formData.get(FormEditor.FORM_ELEMENTS) != null) {
+    if (formData != null && formData.get(FormEditor.FORM_ELEMENTS) != null) {
       Struct formElements = formData.getStruct(FormEditor.FORM_ELEMENTS);
 
       if (formElements.getProperties().values().stream().map(v -> (Struct) v).anyMatch(s -> forbiddenFormFields.contains(s.get("type").toString()))) {


### PR DESCRIPTION
- fix unit tests after form name change to technical name
- an NPE in Studio validator when nor form has been sot so far
- TextValidation when regexp is not set