### PR TITLE
Avoid NPE on missing frontend implementation

### DIFF
--- a/form-editor-cae/src/main/java/com/tallence/formeditor/cae/handler/FormController.java
+++ b/form-editor-cae/src/main/java/com/tallence/formeditor/cae/handler/FormController.java
@@ -196,9 +196,8 @@ public class FormController {
    * @return true, if google says, the token is valid
    */
   private boolean isHumanByReCaptcha(FormEditor target, CMChannel currentContext, MultiValueMap<String, String> postData) {
-    String googleReCaptchaResponse = postData.get("g-recaptcha-response").get(0);
-
     try {
+      String googleReCaptchaResponse = postData.get("g-recaptcha-response").get(0);
       return recaptchaService.isHuman(googleReCaptchaResponse, currentContext);
     } catch (Exception ex) {
       LOG.error("Failed to verify reCapture via google for form " + target.getContentId(), ex);


### PR DESCRIPTION
If the frontend misses to integrate the re-captcha code snippet, avoid to NPE but issue correct failure message to frontend.