### PR TITLE
Add Access to Site specific Re-Captcha Secrets for Frontend

### DIFF
--- a/form-editor-cae/pom.xml
+++ b/form-editor-cae/pom.xml
@@ -88,6 +88,10 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>

--- a/form-editor-cae/pom.xml
+++ b/form-editor-cae/pom.xml
@@ -88,10 +88,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
@@ -142,6 +138,17 @@
     <dependency>
       <groupId>com.coremedia.cms</groupId>
       <artifactId>cap-client-xml</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>image-transformation</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.coremedia.cms</groupId>
+      <artifactId>cap-transform</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/form-editor-cae/src/main/java/com/tallence/formeditor/cae/FormFreemarkerFacade.java
+++ b/form-editor-cae/src/main/java/com/tallence/formeditor/cae/FormFreemarkerFacade.java
@@ -18,11 +18,12 @@ package com.tallence.formeditor.cae;
 
 import com.coremedia.cap.struct.Struct;
 import com.tallence.formeditor.cae.elements.FormElement;
+import com.tallence.formeditor.cae.handler.ReCaptchaService;
 import com.tallence.formeditor.contentbeans.FormEditor;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
 
 /**
  * FreemarkerFacade for Form elements.
@@ -32,7 +33,11 @@ public class FormFreemarkerFacade {
 
   private final FormElementFactory formElementFactory;
 
-  public FormFreemarkerFacade(FormElementFactory formElementFactory) {
+  @Inject
+  private final ReCaptchaService reCaptchaService;
+
+  public FormFreemarkerFacade(FormElementFactory formElementFactory, ReCaptchaService pReCaptchaService) {
+    this.reCaptchaService = pReCaptchaService;
     this.formElementFactory = formElementFactory;
   }
 
@@ -48,6 +53,10 @@ public class FormFreemarkerFacade {
         .filter(e -> e.getValue() instanceof Struct)
         .map(e -> parseElement((Struct) e.getValue(), e.getKey()))
         .collect(Collectors.toList());
+  }
+
+  public String getReCaptchaWebsiteSecretForSite() {
+    return reCaptchaService.getWebsiteSecretForSite(null);
   }
 
   private FormElement parseElement(Struct value, String key) {

--- a/form-editor-cae/src/main/java/com/tallence/formeditor/cae/FormFreemarkerFacade.java
+++ b/form-editor-cae/src/main/java/com/tallence/formeditor/cae/FormFreemarkerFacade.java
@@ -16,6 +16,7 @@
 
 package com.tallence.formeditor.cae;
 
+import com.coremedia.blueprint.common.services.context.CurrentContextService;
 import com.coremedia.cap.struct.Struct;
 import com.tallence.formeditor.cae.elements.FormElement;
 import com.tallence.formeditor.cae.handler.ReCaptchaService;
@@ -33,12 +34,14 @@ public class FormFreemarkerFacade {
 
   private final FormElementFactory formElementFactory;
 
-  @Inject
   private final ReCaptchaService reCaptchaService;
 
-  public FormFreemarkerFacade(FormElementFactory formElementFactory, ReCaptchaService pReCaptchaService) {
+  private CurrentContextService currentContextService;
+
+  public FormFreemarkerFacade(FormElementFactory formElementFactory, ReCaptchaService pReCaptchaService, CurrentContextService currentContextService) {
     this.reCaptchaService = pReCaptchaService;
     this.formElementFactory = formElementFactory;
+    this.currentContextService = currentContextService;
   }
 
   public List<FormElement> parseFormElements(FormEditor formEditor) {
@@ -56,7 +59,7 @@ public class FormFreemarkerFacade {
   }
 
   public String getReCaptchaWebsiteSecretForSite() {
-    return reCaptchaService.getWebsiteSecretForSite(null);
+    return reCaptchaService.getWebsiteSecretForSite(currentContextService.getContext());
   }
 
   private FormElement parseElement(Struct value, String key) {

--- a/form-editor-cae/src/main/resources/META-INF/coremedia/form-freemarker-views.xml
+++ b/form-editor-cae/src/main/resources/META-INF/coremedia/form-freemarker-views.xml
@@ -15,6 +15,7 @@
 
   <bean name="formFreemarkerFacade" class="com.tallence.formeditor.cae.FormFreemarkerFacade">
     <constructor-arg name="formElementFactory" ref="formElementFactory"/>
+    <constructor-arg name="currentContextService" ref="currentContextService"/>
   </bean>
 
   <customize:append id="formFreemarkerConfigurerAutoImportsCustomizer" bean="freemarkerConfigurer"

--- a/form-editor-cae/src/main/resources/lib/form/form.ftl
+++ b/form-editor-cae/src/main/resources/lib/form/form.ftl
@@ -4,3 +4,7 @@
 <#function parseFormElements formEditor>
   <#return formFreemarkerFacade.parseFormElements(formEditor)>
 </#function>
+
+<#function reCaptchaWebsiteSecret>
+  <#return formFreemarkerFacade.getReCaptchaWebsiteSecretForSite()>
+</#function>

--- a/form-editor-cae/src/test/java/com/tallence/formeditor/cae/FormTestConfiguration.java
+++ b/form-editor-cae/src/test/java/com/tallence/formeditor/cae/FormTestConfiguration.java
@@ -84,8 +84,8 @@ public class FormTestConfiguration {
 
   @Bean
   @Scope(SCOPE_SINGLETON)
-  public FormFreemarkerFacade freemarkerFacade(FormElementFactory formElementFactory) {
-    return new FormFreemarkerFacade(formElementFactory);
+  public FormFreemarkerFacade freemarkerFacade(FormElementFactory formElementFactory, ReCaptchaService reCaptchaService) {
+    return new FormFreemarkerFacade(formElementFactory, reCaptchaService);
   }
 
 }

--- a/form-editor-cae/src/test/java/com/tallence/formeditor/cae/FormTestConfiguration.java
+++ b/form-editor-cae/src/test/java/com/tallence/formeditor/cae/FormTestConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.tallence.formeditor.cae;
 
+import com.coremedia.blueprint.common.services.context.CurrentContextService;
 import com.coremedia.blueprint.testing.ContentTestHelper;
 import com.coremedia.cap.test.xmlrepo.XmlRepoConfiguration;
 import com.coremedia.cap.test.xmlrepo.XmlUapiConfig;
@@ -45,6 +46,7 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_SING
         LINK_FORMATTER,
         "classpath:/com/tallence/formeditor/contentbeans/formeditor-contentbeans.xml",
         "classpath:/framework/spring/blueprint-handlers.xml",
+        "classpath:/framework/spring/blueprint-services.xml",
         "classpath:/framework/spring/blueprint-contentbeans.xml"
     },
     reader = ResourceAwareXmlBeanDefinitionReader.class
@@ -84,8 +86,8 @@ public class FormTestConfiguration {
 
   @Bean
   @Scope(SCOPE_SINGLETON)
-  public FormFreemarkerFacade freemarkerFacade(FormElementFactory formElementFactory, ReCaptchaService reCaptchaService) {
-    return new FormFreemarkerFacade(formElementFactory, reCaptchaService);
+  public FormFreemarkerFacade freemarkerFacade(FormElementFactory formElementFactory, ReCaptchaService reCaptchaService, CurrentContextService currentContextService) {
+    return new FormFreemarkerFacade(formElementFactory, reCaptchaService, currentContextService);
   }
 
 }


### PR DESCRIPTION
We needed a site specific implementation of the re-captcha service and thus our frontend needed to fetch the secrets from the configuration.
Hope nothing is missing.
(Should also be cherry-pickable back to cms-9)