### PR TITLE
Improved Checkboxes/Radiobuttons/Selectboxes

### DIFF
--- a/form-editor-cae/src/main/java/com/tallence/formeditor/cae/elements/ComplexValue.java
+++ b/form-editor-cae/src/main/java/com/tallence/formeditor/cae/elements/ComplexValue.java
@@ -16,12 +16,14 @@
 
 package com.tallence.formeditor.cae.elements;
 
+import com.coremedia.blueprint.base.util.StructUtil;
 import com.coremedia.cap.struct.Struct;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Optional;
+
 /**
  * Complex value can be used for CheckBoxes, RadioButtons and SelectBoxes
- *
  */
 public class ComplexValue {
 
@@ -34,15 +36,13 @@ public class ComplexValue {
 
   public ComplexValue(String displayName, Struct data) {
     this.displayName = displayName;
-
-    String tempId = data != null && data.get(PROPERTY_VALUE) != null ? data.getString(PROPERTY_VALUE) : null;
-    this.value = StringUtils.isBlank(tempId) ? displayName : tempId;
-
+    this.value = Optional.ofNullable(data).map(d -> StructUtil.getString(d, PROPERTY_VALUE)).filter(StringUtils::isNotBlank).orElse(displayName);
     this.selectedByDefault = data != null && data.get(CHECKED_BY_DEFAULT) != null && data.getBoolean(CHECKED_BY_DEFAULT);
   }
 
-   /**
+  /**
    * represents the submit value
+   *
    * @return
    */
   public String getValue() {
@@ -51,6 +51,7 @@ public class ComplexValue {
 
   /**
    * represents the display value
+   *
    * @return
    */
   public String getDisplayName() {

--- a/form-editor-cae/src/main/java/com/tallence/formeditor/cae/elements/ComplexValue.java
+++ b/form-editor-cae/src/main/java/com/tallence/formeditor/cae/elements/ComplexValue.java
@@ -17,6 +17,7 @@
 package com.tallence.formeditor.cae.elements;
 
 import com.coremedia.cap.struct.Struct;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Complex value can be used for CheckBoxes, RadioButtons and SelectBoxes
@@ -25,17 +26,35 @@ import com.coremedia.cap.struct.Struct;
 public class ComplexValue {
 
   public static final String CHECKED_BY_DEFAULT = "checkedByDefault";
+  private static final String PROPERTY_VALUE = "value";
 
+  private final String displayName;
   private final String value;
   private final boolean selectedByDefault;
 
-  public ComplexValue(String value, Struct data) {
-    this.value = value;
+  public ComplexValue(String displayName, Struct data) {
+    this.displayName = displayName;
+
+    String tempId = data != null && data.get(PROPERTY_VALUE) != null ? data.getString(PROPERTY_VALUE) : null;
+    this.value = StringUtils.isBlank(tempId) ? displayName : tempId;
+
     this.selectedByDefault = data != null && data.get(CHECKED_BY_DEFAULT) != null && data.getBoolean(CHECKED_BY_DEFAULT);
   }
 
+   /**
+   * represents the submit value
+   * @return
+   */
   public String getValue() {
     return value;
+  }
+
+  /**
+   * represents the display value
+   * @return
+   */
+  public String getDisplayName() {
+    return displayName;
   }
 
   public boolean isSelectedByDefault() {

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/AppliedFormElementContainer.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/AppliedFormElementContainer.mxml
@@ -39,6 +39,10 @@
                                ifUndefined="{getTitleUndefinedValue(config.formElement)}"
                                transformer="{titleTransformer}"
                                bindTo="{config.formElement.getFormElementVE().extendBy('name')}"/>
+        <ui:BindPropertyPlugin bidirectional="false"
+                               componentProperty="iconCls"
+                               transformer="{iconClassTransformer}"
+                               bindTo="{config.formElement.getFormElementVE().extendBy('type')}"/>
         <plugins:ShowFormIssuesPlugin issuesVE="{config.bindTo.extendBy(['issues'])}"
                                       propertyPathVE="{ValueExpressionFactory.createFromValue(config.formElement.getPropertyPath())}"/>
       </components:plugins>

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/AppliedFormElementsContainerBase.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/AppliedFormElementsContainerBase.as
@@ -121,7 +121,6 @@ public class AppliedFormElementsContainerBase extends Container {
   }
 
   public function iconClassTransformer(elementType:String):String {
-    elementType = elementType || formElement.getType();
     var formElementEditor:FormElement = ReusableComponentsServiceImpl.getInstance().requestComponentForReuse(elementType) as FormElement
     return formElementEditor.getFormElementIconCls() || "";
   }

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/AppliedFormElementsContainerBase.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/AppliedFormElementsContainerBase.as
@@ -120,6 +120,12 @@ public class AppliedFormElementsContainerBase extends Container {
     return value ? value : FormUtils.getConditionTitle(formElement.getType())
   }
 
+  public function iconClassTransformer(elementType:String):String {
+    elementType = elementType || formElement.getType();
+    var formElementEditor:FormElement = ReusableComponentsServiceImpl.getInstance().requestComponentForReuse(elementType) as FormElement
+    return formElementEditor.getFormElementIconCls() || "";
+  }
+
   public static function getTitleUndefinedValue(formElement:FormElementStructWrapper):String {
     return FormUtils.getConditionTitle(formElement.getType());
   }

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/FormEditorDocumentForm.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/FormEditorDocumentForm.mxml
@@ -56,6 +56,7 @@
         </Container>
         <!-- right column, applied form elements -->
         <Container flex="1"
+                   layout="anchor"
                    autoScroll="true">
           <items>
             <!-- applied form Elements -->

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/bundles/FormEditor.properties
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/bundles/FormEditor.properties
@@ -22,7 +22,12 @@ FormEditor_label_delete_all_elements=Delete all elements
 FormEditor_delete_elements_title=Delete all elements
 FormEditor_delete_elements_msg=Do you really want to delete all elements?
 FormEditor_text_add_element=Drop a form element here.
+FormEditor_text_label_option=Options
 FormEditor_text_add_option=Add new option
+FormEditor_text_edit_option=Edit option
+FormEditor_text_save_option=Save option
+FormEditor_text_move_option_up=Move option up
+FormEditor_text_move_option_down=Move option down
 FormEditor_text_delete_option=Remove option
 FormEditor_elements_target_title=Selected elements
 FormEditor_label_show_help=Help
@@ -38,6 +43,12 @@ FormEditor_tab_content_title=Content
 FormEditor_tab_formData_title=Form Configuration
 FormEditor_tab_formFields_title=Form Fields
 FormEditor_formAction_default_title=Send mail
+
+FormEditor_element_group_labelField_text=Display name
+FormEditor_element_group_labelField_emptyText=The displayed text for this option. Required.
+FormEditor_element_group_valueField_text=Option value
+FormEditor_element_group_valueField_emptyText=The value to be send during form submit.
+FormEditor_element_group_valueField_hint=Fill in this field only if the option value is to be different from the display name.
 
 FormEditor_element_collapsiblePanel_label=Collapsible form element.
 

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/bundles/FormEditor_de.properties
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/bundles/FormEditor_de.properties
@@ -22,8 +22,13 @@ FormEditor_label_delete_all_elements=Alle Elemente l\u00F6schen
 FormEditor_delete_elements_title=Alle Formularelemente l\u00F6schen
 FormEditor_delete_elements_msg=M\u00F6chten Sie wirklich alle Formularelemente l\u00F6schen?
 FormEditor_text_add_element=Ziehen Sie ein Formularelement hierher.
+FormEditor_text_label_option=Optionen
 FormEditor_text_add_option=Neue Option hinzuf\u00FCgen
-FormEditor_text_delete_option=Option l\u00F6schen
+FormEditor_text_edit_option=Option bearbeiten
+FormEditor_text_save_option_=Option l\u00F6schen
+FormEditor_element_group_save=Option speichern
+FormEditor_text_move_option_up=Option nach oben
+FormEditor_text_move_option_down=Option nach unten
 FormEditor_elements_target_title=Gew\u00E4hlte Elemente
 FormEditor_label_show_help=Hilfe
 FormEditor_help_title=Hilfe zu den Formular-Elementen
@@ -38,6 +43,12 @@ FormEditor_tab_content_title=Inhalt
 FormEditor_tab_formData_title=Formular Konfiguration
 FormEditor_tab_formFields_title=Formularfelder
 FormEditor_formAction_default_title=Mail versenden
+
+FormEditor_element_group_labelField_text=Anzeigename
+FormEditor_element_group_labelField_emptyText=Dieser Wert wird im Formular angezeigt. Erforderlich.
+FormEditor_element_group_valueField_text=Options-Wert
+FormEditor_element_group_valueField_emptyText=Dieser Wert wird beim Senden des Formulares \u00FCbertragen.
+FormEditor_element_group_valueField_hint=F\u00FCllen Sie dieses Feld nur aus, wenn der Options-Wert abweichend vom Anzeigenamen sein soll.
 
 FormEditor_element_collapsiblePanel_label=Einklappbares Formularelement.
 

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/CheckBoxesEditor.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/CheckBoxesEditor.mxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<local:ElementGroupBase
+<local:AbstractFormElement
         xmlns:fx="http://ns.adobe.com/mxml/2009"
         xmlns="exml:ext.config"
         xmlns:local="com.tallence.formeditor.studio.elements.*"
@@ -25,7 +25,7 @@
     <fields:CheckboxField fieldLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_element_mandatory_label')}"
                           propertyName="validator.mandatory"
                           defaultValue="false"/>
-    <fields:AddOptionField propertyName="groupElements"/>
+    <fields:AddOptionField propertyName="groupElements" allowMultiDefaultSelection="true"/>
 
     <fields:NumberField fieldLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_validator_checkboxes_minSize_label')}"
                         emptyText="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_validator_checkboxes_minSize_text')}"
@@ -38,4 +38,4 @@
 
     <advancedsettings:AdvancedSettingsField propertyName="advancedSettings"/>
   </local:items>
-</local:ElementGroupBase>
+</local:AbstractFormElement>

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/ElementGroupEntry.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/ElementGroupEntry.mxml
@@ -2,10 +2,11 @@
 <local:ElementGroupEntryBase
     title="{config.option.getId()}"
     xmlns:fx="http://ns.adobe.com/mxml/2009"
-    xmlns="exml:ext.config" xmlns:ui="exml:com.coremedia.ui.config"
+    xmlns:exml="http://www.jangaroo.net/exml/0.8"
+    xmlns="exml:ext.config"
+    xmlns:ui="exml:com.coremedia.ui.config"
     xmlns:local="com.tallence.formeditor.studio.elements.*"
     xmlns:editor="exml:com.coremedia.cms.editor.sdk.config"
-
     xmlns:u="exml:untyped">
 
   <fx:Script><![CDATA[
@@ -29,21 +30,12 @@
     <Header titlePosition="2.0"
             u:focusableContainer="false"
             u:enableFocusableContainer="false"
-            cls="x-panel-header__core-forms-options"
             itemPosition="2">
+      <plugins exml:mode="append">
+        <ui:BEMPlugin block="core-forms-options-header"
+                      modifier="{getPanelHeaderModifiers(config.option)}" />
+      </plugins>
       <items>
-        <Checkbox autoEl="{{
-                tag: 'div',
-                'data-qtip': resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_element_group_default_tooltip')
-            }}">
-          <plugins>
-            <ui:BindPropertyPlugin bidirectional="true"
-                                   skipIfUndefined="true"
-                                   bindTo="{config.option.getOptionSelectedByDefaultVE()}"/>
-            <editor:BindDisablePlugin bindTo="{config.bindTo}" forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
-          </plugins>
-        </Checkbox>
-
         <ui:IconButton
                 iconAlign="center"
                 iconCls="cm-core-icons cm-core-icons--arrow-up"
@@ -51,7 +43,8 @@
                 ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_move_option_up')}"
                 handler="{moveUp}">
           <ui:plugins>
-            <editor:BindDisablePlugin bindTo="{config.bindTo}" forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
+            <editor:BindDisablePlugin bindTo="{config.bindTo}"
+                                      forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
           </ui:plugins>
         </ui:IconButton>
 
@@ -62,7 +55,8 @@
                 ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_move_option_down')}"
                 handler="{moveDown}">
           <ui:plugins>
-            <editor:BindDisablePlugin bindTo="{config.bindTo}" forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
+            <editor:BindDisablePlugin bindTo="{config.bindTo}"
+                                      forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
           </ui:plugins>
         </ui:IconButton>
 
@@ -73,7 +67,20 @@
                 ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_edit_option')}"
                 handler="{editOption}">
           <ui:plugins>
-            <editor:BindDisablePlugin bindTo="{config.bindTo}" forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
+            <editor:BindDisablePlugin bindTo="{config.bindTo}"
+                                      forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
+          </ui:plugins>
+        </ui:IconButton>
+
+        <ui:IconButton
+                iconAlign="right"
+                iconCls="{resourceManager.getString('com.coremedia.cms.editor.Editor', 'lifecycleStatus_deleted_icon')}"
+                itemId="removeButton"
+                ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_delete_option')}"
+                handler="{removeOption}">
+          <ui:plugins>
+            <editor:BindDisablePlugin bindTo="{config.bindTo}"
+                                      forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
           </ui:plugins>
         </ui:IconButton>
       </items>

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/ElementGroupEntry.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/ElementGroupEntry.mxml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <local:ElementGroupEntryBase
-    padding="0 0 0 100"
     title="{config.option.getId()}"
     xmlns:fx="http://ns.adobe.com/mxml/2009"
     xmlns="exml:ext.config" xmlns:ui="exml:com.coremedia.ui.config"
     xmlns:local="com.tallence.formeditor.studio.elements.*"
     xmlns:editor="exml:com.coremedia.cms.editor.sdk.config"
+
     xmlns:u="exml:untyped">
 
   <fx:Script><![CDATA[
@@ -29,6 +29,7 @@
     <Header titlePosition="2.0"
             u:focusableContainer="false"
             u:enableFocusableContainer="false"
+            cls="x-panel-header__core-forms-options"
             itemPosition="2">
       <items>
         <Checkbox autoEl="{{
@@ -38,20 +39,41 @@
           <plugins>
             <ui:BindPropertyPlugin bidirectional="true"
                                    skipIfUndefined="true"
-                                   bindTo="{config.option.getGroupElementVE().extendBy('checkedByDefault')}"/>
-            <editor:BindDisablePlugin bindTo="{config.bindTo}"
-                                      forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
+                                   bindTo="{config.option.getOptionSelectedByDefaultVE()}"/>
+            <editor:BindDisablePlugin bindTo="{config.bindTo}" forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
           </plugins>
         </Checkbox>
+
         <ui:IconButton
-            iconAlign="right"
-            iconCls="{resourceManager.getString('com.coremedia.cms.editor.Editor', 'lifecycleStatus_deleted_icon')}"
-            itemId="removeButton"
-            ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_delete_option')}"
-            handler="{removeOption}">
+                iconAlign="center"
+                iconCls="cm-core-icons cm-core-icons--arrow-up"
+                itemId="moveButtonUp"
+                ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_move_option_up')}"
+                handler="{moveUp}">
           <ui:plugins>
-            <editor:BindDisablePlugin bindTo="{config.bindTo}"
-                                      forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
+            <editor:BindDisablePlugin bindTo="{config.bindTo}" forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
+          </ui:plugins>
+        </ui:IconButton>
+
+        <ui:IconButton
+                iconAlign="center"
+                iconCls="cm-core-icons cm-core-icons--arrow-down"
+                itemId="moveButtonDown"
+                ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_move_option_down')}"
+                handler="{moveDown}">
+          <ui:plugins>
+            <editor:BindDisablePlugin bindTo="{config.bindTo}" forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
+          </ui:plugins>
+        </ui:IconButton>
+
+        <ui:IconButton
+                iconAlign="right"
+                iconCls="{resourceManager.getString('com.coremedia.cms.editor.Editor', 'lifecycleStatus_checked-out_icon')}"
+                itemId="editButton"
+                ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_edit_option')}"
+                handler="{editOption}">
+          <ui:plugins>
+            <editor:BindDisablePlugin bindTo="{config.bindTo}" forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
           </ui:plugins>
         </ui:IconButton>
       </items>

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/ElementGroupEntryBase.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/ElementGroupEntryBase.as
@@ -15,7 +15,8 @@
  */
 
 package com.tallence.formeditor.studio.elements {
-import com.coremedia.cms.editor.sdk.editorContext;
+
+import com.tallence.formeditor.studio.fields.EditOptionWindow;
 import com.tallence.formeditor.studio.model.GroupElementStructWrapper;
 
 import ext.panel.Panel;
@@ -26,15 +27,49 @@ public class ElementGroupEntryBase extends Panel {
   public var removeGroupElementFn:Function;
 
   [Bindable]
+  public var updateOptionElementFn:Function;
+
+  [Bindable]
+  public var moveOptionElementFn:Function;
+
+  [Bindable]
   public var option:GroupElementStructWrapper;
 
   public function ElementGroupEntryBase(config:ElementGroupEntryBase = null) {
     super(config);
   }
 
-  internal function removeOption():void {
-    this.removeGroupElementFn.call(NaN, this.option.getId());
+  internal function editOption():void {
+
+    function onHandleSave(newId:String, newValue:String, isChecked:Boolean):void {
+      updateOptionElementFn.call(NaN, option, newId, newValue, isChecked);
+    }
+
+    function onHandleRemove():void {
+      removeGroupElementFn.call(NaN, option.getId());
+    }
+
+    var window:EditOptionWindow = new EditOptionWindow(EditOptionWindow({
+      width: 500,
+      title: resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_edit_option') + " '" + this.option.getId() + "'",
+      onSaveCallback: onHandleSave,
+      onRemoveCallback: onHandleRemove,
+      option: this.option
+    }));
+
+    window.show();
   }
 
+  internal function moveUp():void {
+    this.moveOptionElementFn.call(NaN, this.option.getId(), -1);
+  }
+
+  internal function moveDown():void {
+    this.moveOptionElementFn.call(NaN, this.option.getId(), 1);
+  }
+
+
+
 }
+
 }

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/ElementGroupEntryBase.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/ElementGroupEntryBase.as
@@ -16,6 +16,8 @@
 
 package com.tallence.formeditor.studio.elements {
 
+import com.coremedia.ui.data.ValueExpression;
+import com.coremedia.ui.data.ValueExpressionFactory;
 import com.tallence.formeditor.studio.fields.EditOptionWindow;
 import com.tallence.formeditor.studio.model.GroupElementStructWrapper;
 
@@ -37,6 +39,10 @@ public class ElementGroupEntryBase extends Panel {
 
   public function ElementGroupEntryBase(config:ElementGroupEntryBase = null) {
     super(config);
+  }
+
+  internal function removeOption():void {
+    this.removeGroupElementFn.call(NaN, this.option.getId());
   }
 
   internal function editOption():void {
@@ -68,7 +74,15 @@ public class ElementGroupEntryBase extends Panel {
     this.moveOptionElementFn.call(NaN, this.option.getId(), 1);
   }
 
-
+  protected function getPanelHeaderModifiers(option:GroupElementStructWrapper):ValueExpression {
+    return ValueExpressionFactory.createFromFunction(function ():Array {
+      var modifiers:Array = [];
+      if (option.getOptionSelectedByDefaultVE().getValue()) {
+        modifiers.push("selected");
+      }
+      return modifiers;
+    })
+  }
 
 }
 

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/RadioButtonsEditor.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/RadioButtonsEditor.mxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<local:ElementGroupBase
+<local:AbstractFormElement
         xmlns:fx="http://ns.adobe.com/mxml/2009"
         xmlns="exml:ext.config"
         xmlns:local="com.tallence.formeditor.studio.elements.*"
@@ -12,8 +12,6 @@
   <fx:Script><![CDATA[
     public static const xtype:String = "com.tallence.formeditor.studio.elements.radioButtonsEditor";
     public static const FIELD_TYPE:String = "RadioButtons";
-
-    private var config:RadioButtonsEditor;
 
     public native function RadioButtonsEditor(config:RadioButtonsEditor = null);
     ]]></fx:Script>
@@ -31,4 +29,4 @@
     <fields:AddOptionField propertyName="groupElements"/>
     <advancedsettings:AdvancedSettingsField propertyName="advancedSettings"/>
   </local:items>
-</local:ElementGroupBase>
+</local:AbstractFormElement>

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/SelectBoxEditor.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/elements/SelectBoxEditor.mxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<local:ElementGroupBase
+<local:AbstractFormElement
         xmlns:fx="http://ns.adobe.com/mxml/2009"
         xmlns="exml:ext.config"
         xmlns:local="com.tallence.formeditor.studio.elements.*"
@@ -11,8 +11,6 @@
   <fx:Script><![CDATA[
     public static const xtype:String = "com.tallence.formeditor.studio.elements.selectBoxEditor";
     public static const FIELD_TYPE:String = "SelectBox";
-
-    private var config:SelectBoxEditor;
 
     public native function SelectBoxEditor(config:SelectBoxEditor = null);
     ]]></fx:Script>
@@ -30,4 +28,4 @@
     <fields:AddOptionField propertyName="groupElements"/>
     <advancedsettings:AdvancedSettingsField propertyName="advancedSettings"/>
   </local:items>
-</local:ElementGroupBase>
+</local:AbstractFormElement>

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/fields/AddOptionField.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/fields/AddOptionField.mxml
@@ -58,7 +58,7 @@
 
     </FieldContainer>
 
-    <Container width="100%" padding="0 0 0 111">
+    <Container width="100%" padding="0 0 0 105">
       <plugins>
         <ui:BindComponentsPlugin configBeanParameterName="option"
                                  valueExpression="{getGroupElementsVE(config)}">

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/fields/AddOptionField.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/fields/AddOptionField.mxml
@@ -18,12 +18,15 @@
     </fx:Script>
 
   <fields:items>
-    <Container>
+
+    <FieldContainer fieldLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_label_option')}">
       <items>
-        <FieldContainer fieldLabel="{config.fieldLabel}">
+
+        <Container>
           <items>
-            <ui:StatefulTextField width="240"
-                                  fieldLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_add_option')}">
+            <ui:StatefulTextField
+                    flex="1"
+                    emptyText="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_add_option')}">
               <ui:plugins>
                 <editor:BindDisablePlugin bindTo="{config.bindTo}"
                                           forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
@@ -35,34 +38,42 @@
                                               propertyPathVE="{config.propertyPathVE}"/>
               </ui:plugins>
             </ui:StatefulTextField>
+            <ui:IconButton
+                    iconCls="{resourceManager.getString('com.coremedia.cms.editor.Editor', 'LinkListPropertyField_icon')}"
+                    ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_add_option')}"
+                    handler="{addGroupElement}">
+              <ui:plugins>
+                <editor:BindDisablePlugin bindTo="{config.bindTo}"
+                                          forceReadOnlyValueExpression="{getAddOptionButtonDisabledVE()}"/>
+              </ui:plugins>
+            </ui:IconButton>
           </items>
-        </FieldContainer>
-        <ui:IconButton
-                iconCls="{resourceManager.getString('com.coremedia.cms.editor.Editor', 'LinkListPropertyField_icon')}"
-                ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_add_option')}"
-                handler="{addGroupElement}">
-          <ui:plugins>
-            <editor:BindDisablePlugin bindTo="{config.bindTo}"
-                                      forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"/>
-          </ui:plugins>
-        </ui:IconButton>
+          <layout>
+            <layout_HBox align="stretch"/>
+          </layout>
+        </Container>
+
+
       </items>
-      <layout>
-        <layout_HBox align="stretch"/>
-      </layout>
-    </Container>
-    <Container>
+
+    </FieldContainer>
+
+    <Container width="100%" padding="0 0 0 111">
       <plugins>
         <ui:BindComponentsPlugin configBeanParameterName="option"
                                  valueExpression="{getGroupElementsVE(config)}">
           <ui:template>
             <elements:ElementGroupEntry forceReadOnlyValueExpression="{config.forceReadOnlyValueExpression}"
                                         bindTo="{config.bindTo}"
-                                        removeGroupElementFn="{removeGroupElement}"/>
+                                        removeGroupElementFn="{removeGroupElement}"
+                                        updateOptionElementFn="{updateGroupElement}"
+                                        moveOptionElementFn="{moveGroupElement}"
+            />
           </ui:template>
         </ui:BindComponentsPlugin>
       </plugins>
     </Container>
-  </fields:items>
 
+
+  </fields:items>
 </fields:AddOptionFieldBase>

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/fields/AddOptionFieldBase.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/fields/AddOptionFieldBase.as
@@ -22,8 +22,12 @@ import com.tallence.formeditor.studio.FormUtils;
 import com.tallence.formeditor.studio.model.GroupElementStructWrapper;
 
 import ext.MessageBox;
+import ext.util.Format;
 
 public class AddOptionFieldBase extends FormEditorField {
+
+  [Bindable]
+  public var allowMultiDefaultSelection:Boolean = false;
 
   private var addOptionVE:ValueExpression;
   private var formElementsStruct:Struct;
@@ -40,7 +44,7 @@ public class AddOptionFieldBase extends FormEditorField {
     if (newOptionText) {
 
       if (!formElementsStruct.get(groupElementStructName)) {
-        formElementsStruct.getType().addStructProperty(groupElementStructName)
+        formElementsStruct.getType().addStructProperty(groupElementStructName);
       }
       var groupElements:Struct = formElementsStruct.get(groupElementStructName);
       groupElements.getType().addStructProperty(newOptionText);
@@ -58,7 +62,7 @@ public class AddOptionFieldBase extends FormEditorField {
     super.initStruct(struct);
     formElementsStruct = struct;
     if (!formElementsStruct.get(groupElementStructName)) {
-      formElementsStruct.getType().addStructProperty(groupElementStructName)
+      formElementsStruct.getType().addStructProperty(groupElementStructName);
     }
   }
 
@@ -71,22 +75,100 @@ public class AddOptionFieldBase extends FormEditorField {
 
   public function getGroupElementsVE(config:FormEditorField):ValueExpression {
     return ValueExpressionFactory.createFromFunction(function ():Array {
-      var groupsVE:ValueExpression = getPropertyVE(config);
-      if (groupsVE.getValue()) {
-        var groupElementStruct:Struct = groupsVE.getValue();
-        return groupElementStruct.getType().getPropertyNames().map(function (name:String):GroupElementStructWrapper {
-          return new GroupElementStructWrapper(groupsVE.extendBy(name), name);
-        });
-      } else {
-        return undefined;
-      }
-    });
+        var groupsVE:ValueExpression = getPropertyVE(config);
+        if (groupsVE.getValue()) {
+          var groupElementStruct:Struct = groupsVE.getValue();
+          return groupElementStruct.getType().getPropertyNames().map(function (name:String):GroupElementStructWrapper {
+            return new GroupElementStructWrapper(groupsVE.extendBy(name), name, onDefaultSelectionChanged);
+          });
+        } else {
+          return undefined;
+        }
+      });
   }
 
+  /**
+   * remove an option from the list
+   * @param value
+   */
   public function removeGroupElement(value:String):void {
     var groupElementsList:Struct = formElementsStruct.get(groupElementStructName);
     groupElementsList.getType().removeProperty(value);
     FormUtils.reloadPreview();
+  }
+
+  /**
+   * updates an existing option
+   * @param selectedOption existing option
+   * @param newId new display value
+   * @param newValue new option value
+   * @param newChecked new checked state
+   */
+  public function updateGroupElement(selectedOption:GroupElementStructWrapper, newId:String, newValue:String, newChecked:Boolean):void {
+
+    //update sub properties
+    selectedOption.getOptionValueVE().setValue(newValue);
+    selectedOption.getOptionSelectedByDefaultVE().setValue(newChecked);
+
+    //rename struct
+    var groupElementsList:Struct = formElementsStruct.get(groupElementStructName);
+    groupElementsList.getType().renameProperty(selectedOption.getId(), newId);
+
+    FormUtils.reloadPreview();
+  }
+
+  /**
+   * moves an existing option in the list of all available options
+   * @param id option to move
+   * @param moveDistance positions to move, 1 for up, -1 for down
+   */
+  public function moveGroupElement(id:String, moveDistance:Number):void {
+    var groupElementsList:Struct = formElementsStruct.get(groupElementStructName);
+    var optionIds:Array = groupElementsList.getType().getPropertyNames();
+
+    var startingIndex:Number = optionIds.indexOf(id);
+    if (startingIndex == -1) {
+      return;
+    }
+
+    var targetIndex:Number = startingIndex + moveDistance;
+    if (targetIndex >= (optionIds.length)) {
+      targetIndex = 0;
+    }
+    if (targetIndex < 0) {
+      targetIndex = optionIds.length - 1;
+    }
+
+    optionIds.splice(targetIndex, 0, optionIds.splice(startingIndex, 1)[0]);
+
+    groupElementsList.getType().rearrangeProperties(optionIds);
+    FormUtils.reloadPreview();
+  }
+
+  /**
+   * unselect all other options if allowMultiDefaultSelection is false
+   *
+   * @param optionId
+   * @param selected
+   */
+  internal function onDefaultSelectionChanged(optionId:String, selected:Boolean):void {
+    if (!allowMultiDefaultSelection && selected) {
+
+      var groupElementsList:Struct = formElementsStruct.get(groupElementStructName);
+      var optionIds:Array = groupElementsList.getType().getPropertyNames();
+
+      optionIds.forEach(function(id:String):void {
+        var optionStruct:Struct = groupElementsList.get(id);
+        optionStruct.set(GroupElementStructWrapper.PROP_CHECKED, id == optionId)
+      });
+    }
+  }
+
+  protected function getAddOptionButtonDisabledVE():ValueExpression {
+    return ValueExpressionFactory.createFromFunction(function ():Boolean {
+      var optionName:String = getAddOptionVE().getValue();
+      return forceReadOnlyValueExpression.getValue() || optionName == null || !Format.trim(optionName).length;
+    })
   }
 
 }

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/fields/EditOptionWindow.mxml
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/fields/EditOptionWindow.mxml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fields:EditOptionWindowBase
+        xmlns:fx="http://ns.adobe.com/mxml/2009"
+        xmlns:exml="http://www.jangaroo.net/exml/0.8"
+        xmlns="exml:ext.config"
+        xmlns:ui="exml:com.coremedia.ui.config"
+        xmlns:fields="com.tallence.formeditor.studio.fields.*"
+        xmlns:editor="exml:com.coremedia.cms.editor.sdk.config"
+        resizable="false"
+        modal="true">
+  <fx:Metadata>
+    [ResourceBundle('com.coremedia.cms.editor.Editor')]
+  </fx:Metadata>
+  <fx:Script><![CDATA[
+    import com.coremedia.ui.skins.ButtonSkin;
+    import com.coremedia.ui.skins.DisplayFieldSkin;
+
+    private static const FE:String = "com.tallence.formeditor.studio.bundles.FormEditor";
+    public static const xtype:String = "com.tallence.formeditor.studio.editor.fields.editOptionWindow";
+
+    private var config:EditOptionWindow;
+
+    public native function EditOptionWindow(config:EditOptionWindow = null);
+    ]]>
+  </fx:Script>
+  <fields:items>
+    <editor:CollapsibleFormPanel collapsible="false">
+      <editor:items>
+
+        <FieldContainer fieldLabel="{resourceManager.getString(FE, 'FormEditor_element_group_labelField_text')}">
+          <items>
+            <ui:StatefulTextField
+
+                    width="100%"
+                    emptyText="{resourceManager.getString(FE, 'FormEditor_element_group_labelField_emptyText')}">
+              <ui:plugins>
+                <ui:BindPropertyPlugin bidirectional="true" componentProperty="highlighted" bindTo="{getSaveButtonDisabledVE()}"/>
+                <ui:BindPropertyPlugin bidirectional="true" bindTo="{getOptionNameVE()}"/>
+              </ui:plugins>
+            </ui:StatefulTextField>
+          </items>
+        </FieldContainer>
+
+        <editor:FormSpacerElement height="10px"/>
+
+        <FieldContainer fieldLabel="{resourceManager.getString(FE, 'FormEditor_element_group_valueField_text')}">
+          <items>
+            <ui:StatefulTextField
+                    width="100%"
+                    emptyText="{resourceManager.getString(FE, 'FormEditor_element_group_valueField_emptyText')}">
+              <ui:plugins>
+                <ui:BindPropertyPlugin bidirectional="true" bindTo="{getOptionValueVE()}"/>
+              </ui:plugins>
+            </ui:StatefulTextField>
+
+            <DisplayField
+                    value="{resourceManager.getString(FE, 'FormEditor_element_group_valueField_hint')}"
+                    ui="{DisplayFieldSkin.ITALIC.getSkin()}"/>
+          </items>
+        </FieldContainer>
+
+        <editor:FormSpacerElement height="20px"/>
+
+        <Checkbox fieldLabel="{resourceManager.getString(FE, 'FormEditor_element_group_default_tooltip')}">
+          <plugins>
+            <ui:BindPropertyPlugin bidirectional="true"
+                                   skipIfUndefined="true"
+                                   bindTo="{getOptionCheckedVE()}"/>
+          </plugins>
+        </Checkbox>
+      </editor:items>
+    </editor:CollapsibleFormPanel>
+
+  </fields:items>
+  <fields:fbar>
+    <Toolbar>
+      <items>
+        <ui:IconButton
+                iconAlign="right"
+                iconCls="{resourceManager.getString('com.coremedia.cms.editor.Editor', 'lifecycleStatus_deleted_icon')}"
+                itemId="removeButton"
+                ariaLabel="{resourceManager.getString('com.tallence.formeditor.studio.bundles.FormEditor', 'FormEditor_text_delete_option')}"
+                handler="{removeOption}">
+        </ui:IconButton>
+        <TbFill/>
+        <Button ui="{ButtonSkin.FOOTER_PRIMARY.getSkin()}"
+                text="{resourceManager.getString(FE, 'FormEditor_text_save_option')}"
+                handler="{saveOption}"
+                scale="small">
+          <plugins>
+            <ui:BindPropertyPlugin componentProperty="disabled"
+                                   bindTo="{getSaveButtonDisabledVE()}"/>
+          </plugins>
+        </Button>
+
+        <Button ui="{ButtonSkin.FOOTER_SECONDARY.getSkin()}"
+                text="{resourceManager.getString('com.coremedia.cms.editor.Editor', 'dialog_defaultCancelButton_text')}"
+                handler="{close}"
+                scale="small"/>
+      </items>
+    </Toolbar>
+  </fields:fbar>
+
+</fields:EditOptionWindowBase>

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/fields/EditOptionWindowBase.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/fields/EditOptionWindowBase.as
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Tallence AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tallence.formeditor.studio.fields {
+
+import com.coremedia.ui.data.ValueExpression;
+import com.coremedia.ui.data.ValueExpressionFactory;
+import com.tallence.formeditor.studio.model.GroupElementStructWrapper;
+
+import ext.util.Format;
+
+import ext.window.Window;
+
+public class EditOptionWindowBase extends Window {
+
+  protected var option:GroupElementStructWrapper;
+
+  protected var optionNameVE:ValueExpression;
+  protected var optionValueVE:ValueExpression;
+  protected var optionCheckedVE:ValueExpression;
+
+  protected var onSaveCallback:Function;
+  protected var onRemoveCallback:Function;
+
+  public function EditOptionWindowBase(config:EditOptionWindow = null) {
+    super(config);
+
+    this.option = config.option;
+    this.onSaveCallback = config.onSaveCallback;
+    this.onRemoveCallback = config.onRemoveCallback;
+
+    initValues();
+  }
+
+  private function initValues():void {
+    getOptionNameVE().setValue(option.getId());
+    getOptionValueVE().setValue(option.getOptionValueVE().getValue());
+    getOptionCheckedVE().setValue(option.getOptionSelectedByDefaultVE().getValue());
+  }
+
+  public function saveOption():void {
+    if (this.onSaveCallback) {
+      this.onSaveCallback.call(NaN,
+              getOptionNameVE().getValue(),
+              getOptionValueVE().getValue(),
+              getOptionCheckedVE().getValue()
+      );
+      close();
+    }
+  }
+
+  public function removeOption():void {
+    if (this.onRemoveCallback) {
+      this.onRemoveCallback.call(NaN);
+      close();
+    }
+  }
+
+  protected function getOptionNameVE():ValueExpression {
+    if (!optionNameVE) {
+      optionNameVE = ValueExpressionFactory.createFromValue(null);
+    }
+    return optionNameVE;
+  }
+
+  protected function getOptionValueVE():ValueExpression {
+    if (!optionValueVE) {
+      optionValueVE = ValueExpressionFactory.createFromValue(null);
+    }
+    return optionValueVE;
+  }
+
+  protected function getOptionCheckedVE():ValueExpression {
+    if (!optionCheckedVE) {
+      optionCheckedVE = ValueExpressionFactory.createFromValue(false);
+    }
+    return optionCheckedVE;
+  }
+
+  protected function getSaveButtonDisabledVE():ValueExpression {
+    return ValueExpressionFactory.createFromFunction(function ():Boolean {
+      var displayName:String = getOptionNameVE().getValue();
+      return displayName == null || !Format.trim(displayName).length;
+    })
+  }
+
+}
+}

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/model/GroupElementStructWrapper.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/model/GroupElementStructWrapper.as
@@ -19,12 +19,21 @@ import com.coremedia.ui.data.ValueExpression;
 
 public class GroupElementStructWrapper {
 
+  public static const PROP_CHECKED:String = "checkedByDefault";
+  private static const PROP_VALUE:String = "value";
+
   private var groupElementVE:ValueExpression;
   private var id:String;
 
-  public function GroupElementStructWrapper(groupElementVE:ValueExpression, name:String) {
+  public function GroupElementStructWrapper(groupElementVE:ValueExpression, name:String, onSelectionChangeCallback:Function) {
     this.groupElementVE = groupElementVE;
     this.id = name;
+
+    getOptionSelectedByDefaultVE().addChangeListener(function():void {
+        if (onSelectionChangeCallback) {
+          onSelectionChangeCallback.call(NaN, name, getOptionSelectedByDefaultVE().getValue())
+        }
+    });
   }
 
   public function getId():String {
@@ -34,6 +43,15 @@ public class GroupElementStructWrapper {
   public function getGroupElementVE():ValueExpression {
     return groupElementVE;
   }
+
+  public function getOptionSelectedByDefaultVE():ValueExpression {
+    return getGroupElementVE().extendBy(PROP_CHECKED);
+  }
+
+  public function getOptionValueVE():ValueExpression {
+    return getGroupElementVE().extendBy(PROP_VALUE);
+  }
+
 
 }
 }

--- a/form-editor-studio-plugin/src/main/sencha/sass/src/com/tallence/formeditor/studio/FormsStudioPlugin.scss
+++ b/form-editor-studio-plugin/src/main/sencha/sass/src/com/tallence/formeditor/studio/FormsStudioPlugin.scss
@@ -62,7 +62,8 @@
     padding-left: 8px;
   }
 
-  .form-field-advanced-settings .x-panel-header {
+  .form-field-advanced-settings .x-panel-header,
+  .x-panel-header__core-forms-options {
     border: none!important;
     padding-left: 0!important;
   }
@@ -77,6 +78,10 @@
 
   .x-panel-card-200.cm-validation-state-error .x-panel-header.x-collapsed-form-element {
     border-bottom-width: 1px!important;
+  }
+
+  .x-title-icon.tallence-icons {
+    font-weight: normal;
   }
 
 }

--- a/form-editor-studio-plugin/src/main/sencha/sass/src/com/tallence/formeditor/studio/FormsStudioPlugin.scss
+++ b/form-editor-studio-plugin/src/main/sencha/sass/src/com/tallence/formeditor/studio/FormsStudioPlugin.scss
@@ -11,6 +11,10 @@
   $form_element_drop_active: $form_element_block + "--drop-active";
   $form_element_empty: $form_element_block + "--empty";
 
+  $options-header-block: "core-forms-options-header";
+  $options-header-block-selected: $options-header-block + "--selected";
+
+
   .#{$_group_container} {
     border-top: 1px solid;
     border-color: #b3b1b1;
@@ -62,10 +66,26 @@
     padding-left: 8px;
   }
 
-  .form-field-advanced-settings .x-panel-header,
-  .x-panel-header__core-forms-options {
+  .form-field-advanced-settings .x-panel-header{
     border: none!important;
     padding-left: 0!important;
+  }
+
+  .#{$options-header-block} {
+    border: none !important;
+    padding-left: 6px !important;
+    &:hover {
+      background: #f7f7f7;
+    }
+
+    .x-panel-header-title-default {
+      font-weight: normal !important;
+    }
+    &.#{$options-header-block-selected} {
+      .x-panel-header-title-default {
+        font-weight: bold !important;
+      }
+    }
   }
 
   .form-field-advanced-settings .advanced-settings-panel {


### PR DESCRIPTION
- enable reordering and editing of group elements for checkboxes, radiobuttons and selectboxes
- allow only 1 default selection for radiobuttons and selectboxes
- fixes layout issue in Studio when expanding and collapsing panels #1 
- show form type icon for active form elements