### PR TITLE
Update for CoreMedia CMCC 10 2107.3 compatibility

### DIFF
--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/ApplicableElementsBase.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/ApplicableElementsBase.as
@@ -15,7 +15,7 @@
  */
 
 package com.tallence.formeditor.studio {
-import com.coremedia.cms.editor.sdk.premular.CollapsiblePanel;
+import com.coremedia.ui.components.panel.CollapsiblePanel;
 import com.coremedia.ui.data.ValueExpression;
 import com.tallence.formeditor.studio.dragdrop.FormElementDroppable;
 import com.tallence.formeditor.studio.elements.FormElement;

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/AppliedFormElementsContainerBase.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/AppliedFormElementsContainerBase.as
@@ -18,7 +18,7 @@ package com.tallence.formeditor.studio {
 import com.coremedia.cms.editor.sdk.premular.CollapsiblePanel;
 import com.coremedia.cms.editor.sdk.util.PropertyEditorUtil;
 import com.coremedia.ui.data.ValueExpression;
-import com.coremedia.ui.util.ReusableComponentsServiceImpl;
+import com.coremedia.ui.util.reusableComponentsService;
 import com.tallence.formeditor.studio.dragdrop.FormElementDropContainerBase;
 import com.tallence.formeditor.studio.elements.FormElement;
 import com.tallence.formeditor.studio.helper.DragDropHelper;
@@ -71,7 +71,7 @@ public class AppliedFormElementsContainerBase extends Container {
     super.afterRender();
     var panel:CollapsiblePanel = queryById(FORM_ELEMENT_PANEL) as CollapsiblePanel;
 
-    var formElementEditor:FormElement = ReusableComponentsServiceImpl.getInstance().requestComponentForReuse(formElement.getType()) as FormElement;
+    var formElementEditor:FormElement = reusableComponentsService.requestComponentForReuse(formElement.getType()) as FormElement;
     if (formElement != formElementEditor.getFormElementStructWrapper()) {
       formElementEditor.updateFormElementStructWrapper(formElement);
       panel.add(formElementEditor as Component);
@@ -94,7 +94,7 @@ public class AppliedFormElementsContainerBase extends Container {
 
   private function collapsedElementChangeListener(ve:ValueExpression):void {
     if (ve.getValue() == formElement.getId()) {
-      var formElementEditor:FormElement = ReusableComponentsServiceImpl.getInstance().requestComponentForReuse(formElement.getType()) as FormElement;
+      var formElementEditor:FormElement = reusableComponentsService.requestComponentForReuse(formElement.getType()) as FormElement;
       if (formElement != formElementEditor.getFormElementStructWrapper()) {
         formElementEditor.updateFormElementStructWrapper(formElement);
         panel.add(formElementEditor as Component);
@@ -121,7 +121,7 @@ public class AppliedFormElementsContainerBase extends Container {
   }
 
   public function iconClassTransformer(elementType:String):String {
-    var formElementEditor:FormElement = ReusableComponentsServiceImpl.getInstance().requestComponentForReuse(elementType) as FormElement;
+    var formElementEditor:FormElement = reusableComponentsService.requestComponentForReuse(elementType) as FormElement;
     return formElementEditor.getFormElementIconCls() || "";
   }
 
@@ -140,7 +140,7 @@ public class AppliedFormElementsContainerBase extends Container {
    */
   private function removeReusableFormElement():void {
     formElementsManager.getCollapsedElementVE().removeChangeListener(collapsedElementChangeListener);
-    ReusableComponentsServiceImpl.getInstance().removeReusableComponentCleanly(ReusableComponentsServiceImpl.getInstance().requestComponentForReuse(formElement.getType()));
+    reusableComponentsService.removeReusableComponentCleanly(reusableComponentsService.requestComponentForReuse(formElement.getType()));
   }
 }
 }

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/FormEditorDocumentFormBase.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/FormEditorDocumentFormBase.as
@@ -17,8 +17,7 @@
 package com.tallence.formeditor.studio {
 import com.coremedia.cms.editor.sdk.premular.DocumentForm;
 import com.coremedia.ui.data.ValueExpression;
-import com.coremedia.ui.util.IReusableComponentsService;
-import com.coremedia.ui.util.ReusableComponentsServiceImpl;
+import com.coremedia.ui.util.reusableComponentsService;
 import com.tallence.formeditor.studio.elements.AbstractFormElement;
 import com.tallence.formeditor.studio.helper.FormElementsManager;
 
@@ -37,15 +36,14 @@ public class FormEditorDocumentFormBase extends DocumentForm {
    * {@link com.coremedia.ui.util.IReusableComponentsService}, the component must first be created by the
    * {@link ext.ComponentManager}. Then the form editor component is registered and can be used afterwards.
    */
-  protected static function initReusableComponents(formElements:Array):void {
-    var reusableComponentsSerice:IReusableComponentsService = ReusableComponentsServiceImpl.getInstance();
+  protected function initReusableComponents(formElements:Array):void {
     for (var i:int = 0; i < formElements.length; i++) {
       var formElement:AbstractFormElement = AbstractFormElement(ComponentManager.create(formElements[i]));
 
       var key:String = formElement.getFormElementType();
-      if (!reusableComponentsSerice.isReusabilityEnabled(key)) {
-        reusableComponentsSerice.setReusabilityLimit(key, 1);
-        reusableComponentsSerice.registerComponentForReuse(key, formElement);
+      if (!reusableComponentsService.isReusabilityEnabled(key)) {
+        reusableComponentsService.setReusabilityLimit(key, 1);
+        reusableComponentsService.registerComponentForReuse(key, formElement);
       }
     }
   }

--- a/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/components/StateFulCollapsiblePanelBase.as
+++ b/form-editor-studio-plugin/src/main/joo/com/tallence/formeditor/studio/components/StateFulCollapsiblePanelBase.as
@@ -15,7 +15,7 @@
  */
 
 package com.tallence.formeditor.studio.components {
-import com.coremedia.cms.editor.sdk.premular.CollapsiblePanel;
+import com.coremedia.ui.components.panel.CollapsiblePanel;
 import com.coremedia.ui.mixins.IHighlightableMixin;
 import com.coremedia.ui.mixins.IValidationStateMixin;
 import com.coremedia.ui.mixins.ValidationState;


### PR DESCRIPTION
- ReusableComponentsService can no longer be obtained by calling getInstance() (Method is gone). Using the public const reusableComponentsService now. This const is set and initialized during studio startup.
- switch from com.coremedia.cms.editor.sdk.premular.CollapsiblePanel which is marked deprecated since AEP 2010.1 to com.coremedia.ui.components.panel.CollapsiblePanel