### PR TITLE
always use the generated field id for studio validation, required to …

### DIFF
--- a/form-editor-shared/src/main/java/com/tallence/formeditor/elements/AbstractFormElement.java
+++ b/form-editor-shared/src/main/java/com/tallence/formeditor/elements/AbstractFormElement.java
@@ -121,6 +121,11 @@ public abstract class AbstractFormElement<T, V extends Validator<T>> implements 
   }
 
   @Override
+  public String getStructId() {
+    return this.id;
+  }
+
+  @Override
   public String getName() {
     return this.name;
   }

--- a/form-editor-shared/src/main/java/com/tallence/formeditor/elements/FormElement.java
+++ b/form-editor-shared/src/main/java/com/tallence/formeditor/elements/FormElement.java
@@ -30,9 +30,17 @@ import java.util.Map;
  */
 public interface FormElement<T> {
 
+  /**
+   * @return id of the field, gets replaced with customId if available
+   */
   String getId();
 
   void setId(String id);
+
+  /**
+   * @return id of the field, always the generated struct key value, not replaced by customId.
+   */
+  String getStructId();
 
   String getName();
 

--- a/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/CheckBoxesRestrictionsValidator.java
+++ b/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/CheckBoxesRestrictionsValidator.java
@@ -51,25 +51,25 @@ public class CheckBoxesRestrictionsValidator extends AbstractFormValidator<Check
 
     if (minSelection != null) {
       if (minSelection < 0) {
-        addErrorIssue(issues, formElement.getId(), FULLPATH_MIN_SIZE, "checkboxes_options_min_lower_zero", formElement.getName());
+        addErrorIssue(issues, formElement.getStructId(), FULLPATH_MIN_SIZE, "checkboxes_options_min_lower_zero", formElement.getName());
       }
       if (allOptions < minSelection) {
-        addErrorIssue(issues, formElement.getId(), FULLPATH_MIN_SIZE, "checkboxes_options_min_greater_options", formElement.getName());
+        addErrorIssue(issues, formElement.getStructId(), FULLPATH_MIN_SIZE, "checkboxes_options_min_greater_options", formElement.getName());
       }
     }
     if (maxSelection != null) {
       if (maxSelection < 0) {
-        addErrorIssue(issues, formElement.getId(), FULLPATH_MAX_SIZE, "checkboxes_options_max_lower_zero", formElement.getName());
+        addErrorIssue(issues, formElement.getStructId(), FULLPATH_MAX_SIZE, "checkboxes_options_max_lower_zero", formElement.getName());
       }
       if (allOptions < maxSelection) {
-        addErrorIssue(issues, formElement.getId(), FULLPATH_MAX_SIZE, "checkboxes_options_max_lower_options", formElement.getName());
+        addErrorIssue(issues, formElement.getStructId(), FULLPATH_MAX_SIZE, "checkboxes_options_max_lower_options", formElement.getName());
       }
       if (selectedOptions > maxSelection) {
-        addErrorIssue(issues, formElement.getId(), FULLPATH_MAX_SIZE, "checkboxes_options_max_lower_preselection", formElement.getName());
+        addErrorIssue(issues, formElement.getStructId(), FULLPATH_MAX_SIZE, "checkboxes_options_max_lower_preselection", formElement.getName());
       }
     }
     if (minSelection != null && maxSelection != null && minSelection > maxSelection) {
-      addErrorIssue(issues, formElement.getId(), FULLPATH_MAX_SIZE, "checkboxes_options_max_lower_min", formElement.getName());
+      addErrorIssue(issues, formElement.getStructId(), FULLPATH_MAX_SIZE, "checkboxes_options_max_lower_min", formElement.getName());
     }
   }
 

--- a/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/ConsentFormValidator.java
+++ b/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/ConsentFormValidator.java
@@ -39,14 +39,14 @@ public class ConsentFormValidator extends AbstractFormValidator<ConsentFormCheck
 
     String name = formElement.getName();
     if (formElement.getLinkTarget() == null) {
-      addErrorIssue(issues, formElement.getId(), FORM_LINK_TARGET, "consentForm_missing_linkTarget", name);
+      addErrorIssue(issues, formElement.getStructId(), FORM_LINK_TARGET, "consentForm_missing_linkTarget", name);
     }
 
     String hint = formElement.getHint();
     if (StringUtils.isEmpty(hint)) {
-      addErrorIssue(issues, formElement.getId(), FORM_DATA_HINT, "consentForm_missing_hint", name);
+      addErrorIssue(issues, formElement.getStructId(), FORM_DATA_HINT, "consentForm_missing_hint", name);
     } else if (!hint.matches(".*%.+%.*")) {
-      addErrorIssue(issues, formElement.getId(), FORM_DATA_HINT, "consentForm_invalid_hint", name);
+      addErrorIssue(issues, formElement.getStructId(), FORM_DATA_HINT, "consentForm_invalid_hint", name);
     }
   }
 }

--- a/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/NameNotEmptyValidator.java
+++ b/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/NameNotEmptyValidator.java
@@ -39,7 +39,7 @@ public class NameNotEmptyValidator extends AbstractFormValidator<AbstractFormEle
   @Override
   void validateField(AbstractFormElement<?, ?> formElement, String action, Issues issues) {
     if (StringUtils.isEmpty(formElement.getName())) {
-      addErrorIssue(issues, formElement.getId(), FORM_DATA_NAME, "formField_missing_name", formElement.getClass().getSimpleName());
+      addErrorIssue(issues, formElement.getStructId(), FORM_DATA_NAME, "formField_missing_name", formElement.getClass().getSimpleName());
     }
   }
 

--- a/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/NoFileUploadOnMailActionValidator.java
+++ b/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/NoFileUploadOnMailActionValidator.java
@@ -36,7 +36,7 @@ public class NoFileUploadOnMailActionValidator extends AbstractFormValidator<Fil
   @Override
   void validateField(FileUpload formElement, String action, Issues issues) {
     if (FormEditor.MAIL_ACTION.equals(action)) {
-      addErrorIssue(issues, formElement.getId(), FORM_DATA_NAME, "form_action_mail_file");
+      addErrorIssue(issues, formElement.getStructId(), FORM_DATA_NAME, "form_action_mail_file");
     }
   }
 }

--- a/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/NumberFieldValidator.java
+++ b/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/NumberFieldValidator.java
@@ -34,7 +34,7 @@ public class NumberFieldValidator extends AbstractFormValidator<NumberField> {
   void validateField(NumberField formElement, String action, Issues issues) {
     var validator = formElement.getValidator();
     if (validator != null) {
-      validateMaxAndMinSize(validator, issues, formElement.getId(), formElement.getName());
+      validateMaxAndMinSize(validator, issues, formElement.getStructId(), formElement.getName());
     }
   }
 

--- a/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/OptionsNotEmptyValidator.java
+++ b/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/OptionsNotEmptyValidator.java
@@ -38,7 +38,7 @@ public class OptionsNotEmptyValidator extends AbstractFormValidator<FieldWithOpt
     if (formElement.getOptions().isEmpty()) {
 
       String messageKey = formElement.getClass().getSimpleName().toLowerCase() + "_missing_options";
-      addErrorIssue(issues, formElement.getId(), FORM_GROUP_ELEMENTS_PROPERTY_NAME, messageKey, formElement.getName());
+      addErrorIssue(issues, formElement.getStructId(), FORM_GROUP_ELEMENTS_PROPERTY_NAME, messageKey, formElement.getName());
     }
 
   }

--- a/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/TextAreaValidator.java
+++ b/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/TextAreaValidator.java
@@ -34,7 +34,7 @@ public class TextAreaValidator extends AbstractFormValidator<TextArea> {
   void validateField(TextArea formElement, String action, Issues issues) {
     var validator = formElement.getValidator();
     if (validator != null) {
-      validateMaxAndMinSize(validator, issues, formElement.getId(), formElement.getName());
+      validateMaxAndMinSize(validator, issues, formElement.getStructId(), formElement.getName());
     }
   }
 

--- a/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/TextFieldValidator.java
+++ b/form-editor-studio-lib/src/main/java/com/tallence/formeditor/studio/validator/field/TextFieldValidator.java
@@ -43,7 +43,7 @@ public class TextFieldValidator extends AbstractFormValidator<TextField> {
   void validateField(TextField formElement, String action, Issues issues) {
     var validator = formElement.getValidator();
     if (validator != null) {
-      validateFieldValidators(validator, issues, formElement.getId(), formElement.getName());
+      validateFieldValidators(validator, issues, formElement.getStructId(), formElement.getName());
     }
   }
 


### PR DESCRIPTION
…highlight the correct field inside the studio form

